### PR TITLE
Spoof webview package name

### DIFF
--- a/app/src/main/java/info/plateaukao/einkbro/EinkBroApplication.kt
+++ b/app/src/main/java/info/plateaukao/einkbro/EinkBroApplication.kt
@@ -9,6 +9,7 @@ import android.content.Intent
 import android.content.SharedPreferences
 import android.content.pm.PackageManager
 import android.os.Build
+import android.os.Looper
 import android.preference.PreferenceManager
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.core.app.ActivityCompat
@@ -27,6 +28,7 @@ import info.plateaukao.einkbro.search.suggestion.SearchSuggestionViewModel
 import info.plateaukao.einkbro.service.InstapaperRepository
 import info.plateaukao.einkbro.service.TtsManager
 import info.plateaukao.einkbro.unit.LocaleManager
+import info.plateaukao.einkbro.util.WebViewUtil
 import io.github.edsuns.adfilter.AdFilter
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
@@ -173,6 +175,24 @@ class EinkBroApplication : Application() {
                 }
             }
         }
+    }
+
+    // This snippet borrow from mihon
+    // https://github.com/mihonapp/mihon/blob/81871a34694c8e408d907731292b7266c5b993cc/app/src/main/java/eu/kanade/tachiyomi/App.kt#L231
+    override fun getPackageName(): String {
+        try {
+            // Override the value passed as X-Requested-With in WebView requests
+            val stackTrace = Looper.getMainLooper().thread.stackTrace
+            val isChromiumCall = stackTrace.any { trace ->
+                trace.className.lowercase() in setOf("org.chromium.base.buildinfo", "org.chromium.base.apkinfo") &&
+                        trace.methodName.lowercase() in setOf("getall", "getpackagename", "<init>")
+            }
+
+            if (isChromiumCall) return WebViewUtil.spoofedPackageName(applicationContext)
+        } catch (_: Exception) {
+        }
+
+        return super.getPackageName()
     }
 
     companion object {

--- a/app/src/main/java/info/plateaukao/einkbro/util/WebViewUtil.kt
+++ b/app/src/main/java/info/plateaukao/einkbro/util/WebViewUtil.kt
@@ -1,0 +1,22 @@
+package info.plateaukao.einkbro.util
+
+import android.content.Context
+import android.content.pm.PackageManager
+
+object WebViewUtil {
+    // This snippet is borrow from mihon
+    // https://github.com/mihonapp/mihon/blob/81871a34694c8e408d907731292b7266c5b993cc/core/common/src/main/kotlin/eu/kanade/tachiyomi/util/system/WebViewUtil.kt#L14
+    private const val CHROME_PACKAGE = "com.android.chrome"
+    private const val SYSTEM_SETTINGS_PACKAGE = "com.android.settings"
+
+    fun spoofedPackageName(context: Context): String {
+        return try {
+            context.packageManager.getPackageInfo(CHROME_PACKAGE, PackageManager.GET_META_DATA)
+
+            CHROME_PACKAGE
+        } catch (_: PackageManager.NameNotFoundException) {
+            SYSTEM_SETTINGS_PACKAGE
+        }
+    }
+    // end snippet
+}


### PR DESCRIPTION
Currently, when makes web requests, it sends the app's actual package name in the X-Requested-With header. Many websites actively block or restrict traffic that doesn't originate from a recognized browser package. By spoofing the package name, we can bypass these restrictions.

The logic for this workaround was borrowed and adapted from [mihon#2491](https://github.com/mihonapp/mihon/pull/2491)