### PR TITLE
fix: Fix the duplicate tab issue when connecting/disconnecting a bluetooth keyboard

### DIFF
--- a/app/src/main/java/info/plateaukao/einkbro/activity/BrowserActivity.kt
+++ b/app/src/main/java/info/plateaukao/einkbro/activity/BrowserActivity.kt
@@ -974,6 +974,10 @@ open class BrowserActivity : FragmentActivity(), BrowserController {
 
         initDownloadReceiver()
 
+        // ViewModel survives activity recreation (e.g. keyboard config change + recreate()).
+        // Clear stale album entries so initSavedTabs() doesn't append duplicates
+        albumViewModel.clearAlbums();
+
         dispatchIntent(intent)
         intentDispatchDelegate.shouldLoadTabState = false
 

--- a/app/src/main/java/info/plateaukao/einkbro/activity/delegates/DisplayConfigDelegate.kt
+++ b/app/src/main/java/info/plateaukao/einkbro/activity/delegates/DisplayConfigDelegate.kt
@@ -41,7 +41,7 @@ class DisplayConfigDelegate(
     fun onConfigurationChanged(newConfig: Configuration) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
             val nightModeFlags =
-                activity.resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK
+                newConfig.uiMode and Configuration.UI_MODE_NIGHT_MASK
             if (nightModeFlags != uiMode && config.display.darkMode == DarkMode.SYSTEM) {
                 activity.recreate()
                 return

--- a/app/src/main/java/info/plateaukao/einkbro/viewmodel/AlbumViewModel.kt
+++ b/app/src/main/java/info/plateaukao/einkbro/viewmodel/AlbumViewModel.kt
@@ -18,4 +18,8 @@ class AlbumViewModel: ViewModel() {
             remove(album)
         }
     }
+
+    fun clearAlbums() {
+        albums.value = emptyList()
+    }
 }


### PR DESCRIPTION
---
name: Bug fix
title: 'Fix duplicate tab issue when connecting/disconnecting a bluetooth keyboard'
labels: ''
assignees: 
---

Please write necessary information as described below. If information is not enough, I may not have time to look into it.

**What device and app version are you using**

 - Device: Only Boox Tab Ultra C Pro
 - OS: Android Version 13
 - EinkBro Version v15.12.0 (-4171917)

**Describe the bug**

A clear and concise description of what the bug is.

**To Reproduce**
Steps to reproduce the behavior.
1. Open EinkPro and open some random tab (assume we have tabA, tabB)
2. Connect a bluetooth keyboard, the tab will duplicate (it will become tabA, tabB, tabA, tabB)
3. Disconnect a bluetooth keyboard, the tab will duplicate again (it will become tabA, tabB, tabA, tabB, tabA, tabB)

** What's the behavior on following similar browsers **
* Via Browser
* xBrowser
It won't duplicate the tab unnecessary

**Do not report that it works in CHROME, FIREFOX, or EDGE, BRAVE. That does not help. Since these are full-fledge browsers**
  
**Expected behavior**
The tab won't duplicate

A clear and concise description of what you expected to happen.

**Screenshots**

If applicable, add screenshots to help explain your problem.

**Additional context**

Add any other context about the problem here.



Bug diagnosis:

  AlbumViewModel is an Android ViewModel (via by viewModels()) and survives activity recreation across configuration changes. BrowserState is a plain class created fresh on each
  onCreate, so currentAlbumController resets to null.

  When a Bluetooth keyboard connects/disconnects, onConfigurationChanged fires. DisplayConfigDelegate was reading night-mode bits from activity.resources.configuration.uiMode
  (which can be inconsistent) instead of newConfig.uiMode. On some e-ink devices, this caused a spurious activity.recreate() call on keyboard events.

  After recreation:
  - BrowserState.currentAlbumController == null → initSavedTabs guard passes
  - AlbumViewModel.albums still holds [tabA, tabB] from the old instance
  - initSavedTabs reloads from storage and appends → [tabA, tabB, tabA, tabB]

  Two fixes applied:

  1. AlbumViewModel.kt: Added clearAlbums() method
  2. BrowserActivity.onCreate(): Call albumViewModel.clearAlbums() before dispatchIntent() — ensures stale ViewModel data is wiped before tabs are restored, regardless of what
  caused the recreation
  3. DisplayConfigDelegate.kt: Use newConfig.uiMode instead of activity.resources.configuration.uiMode — prevents spurious recreate() calls from inconsistent resource state
  during keyboard config changes